### PR TITLE
Also report lint-free files

### DIFF
--- a/jshint-junit-xml-formatter.js
+++ b/jshint-junit-xml-formatter.js
@@ -1,5 +1,4 @@
 /*jshint node:true */
-
 /* Adapted from the default JSHint xml formatter by Derek Prior
  *  http://prioritized.net
  *
@@ -8,9 +7,15 @@
  */
 module.exports =
 {
-  reporter: function (results)
+  reporter: function (results, o)
   {
     "use strict";
+
+    var linted = o.map(function(file) {
+      return file.file;
+    }).filter(function(file) {
+      return file;
+    });
 
     var suite = 'jshint';
     var files = {};
@@ -62,13 +67,14 @@ module.exports =
     out.push("<?xml version=\"1.0\" encoding=\"utf-8\"?>");
     out.push("<testsuite name=\"" + suite + "\" tests=\"" + Object.keys(files).length + "\" failures=\"" + results.length + "\" errors=\"0\" >");
 
-    for (var file in files) {
+    linted.forEach(function(file) {
+      if(!files[file]) return out.push("\t<testcase name=\"" + file + "\"></testcase>");
       out.push("\t<testcase name=\"" + file + "\">");
       out.push("\t\t<failure message=\"" + failure_message(files[file]) + "\" >");
       out.push(failure_details(files[file]));
       out.push("\t\t</failure>");
       out.push("\t</testcase>");
-    }
+    });
 
     out.push("</testsuite>");
     process.stdout.write(out.join("\n") + "\n");


### PR DESCRIPTION
Hi @derekprior

Here is a little change for you to review! And merge in if you feel it.

Not sure whether or not it's tied to my Jenkins / Junit plugin setup, but I had to make sure to also report files that are marked as lint-free to be able to report back the results. And properly exit the build with a success status.

Example running `jshint jshint-junit-xml-formatter.js --reporter jshint-junit-xml-formatter.js`:

``` xml
<?xml version="1.0" encoding="utf-8"?>
<testsuite name="jshint" tests="0" failures="0" errors="0" >
    <testcase name="jshint-junit-xml-formatter.js"></testcase>
</testsuite>
```

Thanks for your reporter, I was really glad to find one while setting up this jshint job.
